### PR TITLE
Attempt to separate raycasting and infobox calls from shopping/building script

### DIFF
--- a/ControlNodes/BuildAndShop/Cursor.gd
+++ b/ControlNodes/BuildAndShop/Cursor.gd
@@ -1,0 +1,102 @@
+extends Control
+
+
+var viewport: Viewport
+var selectedDeckNumber: int
+var hit: Dictionary = {}
+var selected = null
+var info: Control = null
+
+var leftClick: bool = false
+var rightClick: bool = false
+var scrollUp: bool = false
+var scrollDown: bool = false
+
+var shopper = null
+var builder = null
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	GlobalObjectReferencer.cursor = self
+	viewport = get_tree().get_root().get_node("GameWorld/ViewportContainer/Viewport")
+	selectedDeckNumber = -1
+	info = get_node("Info")
+
+
+# Catches only the input which has not been handled yet.
+func _unhandled_input(event):
+	if event.is_action_pressed("leftClick") && !event.is_echo():
+		leftClick = true
+	if event.is_action_pressed("rightClick") && !event.is_echo():
+		rightClick = true
+	if event.is_action_released("rotateItemLeft"):
+		scrollUp = true
+	if event.is_action_released("rotateItemRight"):
+		scrollDown = true
+
+
+# Called every physics frame. 'delta' is the elapsed time since the previous frame.
+func _physics_process(delta):
+	scan() # raycasts to set the dictionary called hit
+	# on leftclick, if shop is closed, if hit has info, open info box
+	if GlobalObjectReferencer.shopping.open == null:
+		if leftClick: # and not in shop or building
+			if !hit.empty() && hit.collider.has_method("createInfo"):
+				if is_instance_valid(selected):
+					selected.removeInfo()
+				selected = hit.collider
+				info2(selected)
+				selected.createInfo(info)
+			elif is_instance_valid(selected):
+				selected.removeInfo()
+				selected = null
+		if is_instance_valid(selected):
+			info2(selected)
+	elif is_instance_valid(selected):
+		selected.removeInfo()
+		selected = null
+	resetInput()
+
+
+# Resets input.
+func resetInput():
+	leftClick = false
+	rightClick = false
+	scrollUp = false
+	scrollDown = false
+
+
+# Raycasts on cursor to set lastHit.
+func scan():
+	var selectedDeck = null
+	if selectedDeckNumber != -1:
+		selectedDeck = get_tree().get_nodes_in_group("PlayerDeck")[selectedDeckNumber]
+	var camera: Camera = viewport.get_camera()
+	var spaceState: PhysicsDirectSpaceState = camera.get_world().direct_space_state
+	var viewportContainer: ViewportContainer = viewport.get_parent()
+	var cursor = get_viewport().get_mouse_position() / viewportContainer.stretch_shrink
+	var toIgnore: Array = []
+	if is_instance_valid(GlobalObjectReferencer.shopping.hologram):
+		toIgnore.append(GlobalObjectReferencer.shopping.hologram)
+	var from = camera.project_ray_origin(cursor)
+	var toward = camera.project_ray_normal(cursor)
+	hit = spaceState.intersect_ray(from, from + toward * 2000, toIgnore, 0b1)
+	while !hit.empty() && selectedDeck != null && hit.collider != selectedDeck && hit.collider.get_parent() != selectedDeck && hit.collider.name != "HTerrain":
+		toIgnore.append(hit.collider)
+		hit = spaceState.intersect_ray(from, from + toward * 2000, toIgnore, 0b1)
+#	if !hit.empty():
+#		print(hit.collider.name)
+
+
+# Updates location of infobox to hover above the given thing.
+func info2(thing):
+	var camera: Camera = viewport.get_camera()
+	var viewportContainer: ViewportContainer = viewport.get_parent()
+	var pos: Vector2 = camera.unproject_position(selected.global_transform.origin)
+	info.rect_position = Vector2(clamp(pos.x, 0, viewport.size.x), clamp(pos.y, 0, viewport.size.y)) * viewportContainer.stretch_shrink
+
+
+# Changes the selected deck number to the given integer.
+func selectDeck(deckNumber: int):
+	selectedDeckNumber = deckNumber

--- a/ControlNodes/BuildAndShop/Cursor.tscn
+++ b/ControlNodes/BuildAndShop/Cursor.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://ControlNodes/BuildAndShop/Cursor.gd" type="Script" id=1]
+
+[node name="Cursor" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Info" type="Control" parent="."]
+mouse_filter = 2

--- a/ControlNodes/BuildAndShop/Shopping.tscn
+++ b/ControlNodes/BuildAndShop/Shopping.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=5 format=2]
 
-[ext_resource path="res://icon.png" type="Texture" id=1]
 [ext_resource path="res://ControlNodes/BuildAndShop/Shopping.gd" type="Script" id=2]
 [ext_resource path="res://ControlNodes/Images/buildButton.png" type="Texture" id=3]
 [ext_resource path="res://ControlNodes/Images/buildButtonPressed.png" type="Texture" id=4]
@@ -79,27 +78,6 @@ flat = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
-
-[node name="Info" type="Control" parent="."]
-visible = false
-margin_right = 40.0
-margin_bottom = 40.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Label" type="Label" parent="Info"]
-margin_right = 40.0
-margin_bottom = 14.0
-text = "testing"
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="TextureRect" type="TextureRect" parent="Info"]
-margin_right = 40.0
-margin_bottom = 40.0
-texture = ExtResource( 1 )
 
 [connection signal="pressed" from="Indicator" to="." method="_on_indicator"]
 [connection signal="pressed" from="Shop/Sell" to="." method="sell"]

--- a/ObjectNodes/Camera/GameCamera.gd
+++ b/ObjectNodes/Camera/GameCamera.gd
@@ -126,10 +126,11 @@ func _unhandled_input(event):
 
 # Changes camera position according to the chosen deck.
 func selectDeck(deckNumber):
-	var difference = deckNumber * 2
-	if targetPos.y > 20 - difference:
-		targetPos.y = 20 - difference
-		do_center = true
+	if deckNumber != -1:
+		var difference = deckNumber * 2
+		if targetPos.y > 20 - difference:
+			targetPos.y = 20 - difference
+			do_center = true
 
 
 func mouseRotate():
@@ -151,11 +152,16 @@ func checkToggleOnHeight(heightThresh):
 	"""
 	if translation.y>heightThresh and heightToggle:
 		GlobalObjectReferencer.playerShip.toggleDeckVisible(-1)
-		shopping.selected_deck = -1
+		var deckButtons = get_tree().get_root().get_node("GameWorld/Interface/Decks")
+		for deckButton in deckButtons.get_children():
+			var theButton = get_node_or_null("TextureButton")
+			if is_instance_valid(theButton):
+				theButton.pressed = false
+		GlobalObjectReferencer.camera.selectDeck(-1)
+		GlobalObjectReferencer.cursor.selectDeck(-1)
 		var decks = get_tree().get_root().get_node("GameWorld/Interface/Decks")
 		for child in decks.get_children():
 			child.get_node("TextureButton").pressed = false
 		heightToggle = false
 	if translation.y<heightThresh:
 		heightToggle = true
-

--- a/ObjectNodes/ShipRigidController/RigidShipController.gd
+++ b/ObjectNodes/ShipRigidController/RigidShipController.gd
@@ -64,7 +64,7 @@ func _ready():
 			# iterate through children, skip 1st because it is Sails
 			a[i].add_to_group("PlayerDeck")
 		reloadDecks(2)
-			
+
 func registerItem(node):
 	"""
 	Adds Item to array containing all items that are on ship.
@@ -176,19 +176,17 @@ func toggleDeckVisible(deckNumber : int):
 
 # Changes visibility according to the chosen deck on each button press.
 func selectDeck(deckNumber: int):
-	print("deck presed")
 	var decks = get_tree().get_root().get_node("GameWorld/Interface/Decks")
 	for child in decks.get_children():
 		if child.name != str(deckNumber):
 			child.get_node("TextureButton").pressed = false
 		else:
 			var theButton = child.get_node("TextureButton")
-			if theButton.pressed:
-				toggleDeckVisible(deckNumber)
-			else:
-				toggleDeckVisible(-1)
+			if !theButton.pressed:
+				deckNumber = -1
+	toggleDeckVisible(deckNumber)
 	GlobalObjectReferencer.camera.selectDeck(deckNumber)
-	GlobalObjectReferencer.shopping.selectDeck(deckNumber)
+	GlobalObjectReferencer.cursor.selectDeck(deckNumber)
 
 
 # Recreates and binds buttons for decks.

--- a/SceneNodes/GlobalObjectReferencer.gd
+++ b/SceneNodes/GlobalObjectReferencer.gd
@@ -12,6 +12,7 @@ var playerShip  = null # reference to playerShip, the object itself will set thi
 var camera      = null # reference to camera, the object itself will set this variable when ready
 var viewport    = null # ref to viewport, set in terminal.gd
 var crewManager = null # ref to CrewMaanager, (ssumes it will be a singleton so dont copy on NPC ships)
-var shopping    = null # ref to shopping.gd, shopping.gd sets this in its ready() function
+var shopping    = null
+var cursor      = null
 
 ## .. add more stuff here


### PR DESCRIPTION
There is a new node called Cursor.tscn. Add a copy of it under Interface in the main scene. I've tried to fix some minor stuff as well, and simplified somethings. Shop should automatically close when zoomed out. Uppermost deck should be selected when shop is open first. You don't need separate deck collision layers anymore, but still each deck must stay as individual bodies. So everything is supposed to be on the first collision layer now. You can untick other collision layers.