### PR TITLE
Created fast and basic offscreen indicators (almost cost free)

### DIFF
--- a/ControlNodes/Indicators/Indicators.tscn
+++ b/ControlNodes/Indicators/Indicators.tscn
@@ -1,0 +1,9 @@
+[gd_scene format=2]
+
+[node name="Indicators" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/ControlNodes/Indicators/mark.tscn
+++ b/ControlNodes/Indicators/mark.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://icon.png" type="Texture" id=1]
+
+[node name="Sprite" type="Sprite"]
+texture = ExtResource( 1 )


### PR DESCRIPTION
To make it work and not crash the game, you'll need to add that indicators.tscn under ControlNodes/Indicators, to under the Interface node in the main scene. I've tested it before, and for some reason it doesn't work as intended on angled camera, but since this game is top-down only, it works without any problems. You can change default icon inside the sprite called mark.tscn in the same indicators folder.